### PR TITLE
Move pyupgrade pre-commit to its own python39 file

### DIFF
--- a/nitpick-style-base.toml
+++ b/nitpick-style-base.toml
@@ -11,6 +11,7 @@ include = [
     "styles/pre-commit/main",
     "styles/pre-commit/general",
     "styles/pre-commit/python",
+    "styles/pre-commit/python39",
     "styles/pre-commit/bash",
     "styles/black",
     "styles/flake8",

--- a/nitpick-style-orchestrator-core.toml
+++ b/nitpick-style-orchestrator-core.toml
@@ -20,3 +20,7 @@ include = [
     "styles/orchestrator-core",
     "styles/mypy-pydantic",
 ]
+
+
+[nitpick.files."setup.cfg"]
+comma_separated_values = ["flake8.ignore", "flake8.exclude"]

--- a/nitpick-style-orchestrator-core.toml
+++ b/nitpick-style-orchestrator-core.toml
@@ -6,7 +6,6 @@ minimum_version = "0.23.1"
 
 [nitpick.styles]
 include = [
-    "styles/python39",
     "styles/absent-files",
     "styles/pre-commit/main",
     "styles/pre-commit/general",

--- a/styles/pre-commit/python.toml
+++ b/styles/pre-commit/python.toml
@@ -6,11 +6,4 @@ yaml = """
       - id: python-check-blanket-noqa
       - id: python-check-mock-methods
       - id: rst-backticks
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
-    hooks:
-      - id: pyupgrade
-        args:
-          - --py39-plus
-          - --keep-runtime-typing
 """

--- a/styles/pre-commit/python39.toml
+++ b/styles/pre-commit/python39.toml
@@ -1,0 +1,10 @@
+[["pre-commit-config.yaml".repos]]
+yaml = """
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.29.0
+    hooks:
+      - id: pyupgrade
+        args:
+          - --py39-plus
+          - --keep-runtime-typing
+"""


### PR DESCRIPTION
needed for orchestrator core. which is supported from 3.6 and up.