### PR TITLE
CI notifications for scheduled jobs in gitlab

### DIFF
--- a/ci/gitlab/notifications.yml
+++ b/ci/gitlab/notifications.yml
@@ -9,8 +9,7 @@
   dependencies: []  # No artifacts
   before_script:
     - apk update && apk add bash curl
-    # - wget --quiet https://raw.githubusercontent.com/workfloworchestrator/nitpick-style/main/ci/scripts/slack.sh
-    - wget --quiet https://raw.githubusercontent.com/workfloworchestrator/nitpick-style/1256-slack-notify/ci/scripts/slack.sh
+    - wget --quiet https://raw.githubusercontent.com/workfloworchestrator/nitpick-style/main/ci/scripts/slack.sh
     - chmod +x slack.sh
 
 

--- a/ci/gitlab/notifications.yml
+++ b/ci/gitlab/notifications.yml
@@ -1,0 +1,49 @@
+# Gitlab-CI template to send slack notifications for scheduled 'build' and 'unit test' jobs.
+# Required environment variables:
+#   CI_SLACK_NOTIFICATION_CHANNEL: name of channel to post to
+#   CI_SLACK_WEBHOOK_URL: slack webhook url
+
+.notify:
+  stage: notification
+  image: alpine
+  dependencies: []  # No artifacts
+  before_script:
+    - apk update && apk add bash curl
+    # - wget --quiet https://raw.githubusercontent.com/workfloworchestrator/nitpick-style/main/ci/scripts/slack.sh
+    - wget --quiet https://raw.githubusercontent.com/workfloworchestrator/nitpick-style/1256-slack-notify/ci/scripts/slack.sh
+    - chmod +x slack.sh
+
+
+.only-nwa-schedules:
+  only:
+    refs:
+      - schedules@netdev/automation
+
+
+schedule:notify-test-success:
+  extends:
+#    - .only-nwa-schedules  # TODO UNCOMMENT BEFORE MERGING
+    - .notify
+  script:
+      - ./slack.sh $CI_SLACK_NOTIFICATION_CHANNEL "Successfully built and tested $CI_PROJECT_TITLE $CI_JOB_URL" white_check_mark "Gitlab Pipeline"
+  needs: ["unit test"]
+  when: on_success
+
+
+schedule:notify-build-failed:
+  extends:
+#    - .only-nwa-schedules  # TODO UNCOMMENT BEFORE MERGE
+    - .notify
+  script:
+    - ./slack.sh $CI_SLACK_NOTIFICATION_CHANNEL "Build failed for $CI_PROJECT_TITLE $CI_JOB_URL" zap "Gitlab Pipeline"
+  needs: ["build"]
+  when: on_failure
+
+schedule:notify-test-failed:
+  extends:
+#    - .only-nwa-schedules  # TODO UNCOMMENT BEFORE MERGE
+    - .notify
+  script:
+    - ./slack.sh $CI_SLACK_NOTIFICATION_CHANNEL "Successful build but failed test $CI_PROJECT_TITLE $CI_JOB_URL" zap "Gitlab Pipeline"
+  needs: ["unit test"]
+  when: on_failure

--- a/ci/gitlab/notifications.yml
+++ b/ci/gitlab/notifications.yml
@@ -7,31 +7,25 @@
   stage: notification
   image: alpine
   dependencies: []  # No artifacts
+  only:
+    refs:
+      - schedules@netdev/automation
   before_script:
     - apk update && apk add bash curl
     - wget --quiet https://raw.githubusercontent.com/workfloworchestrator/nitpick-style/main/ci/scripts/slack.sh
     - chmod +x slack.sh
 
 
-.only-nwa-schedules:
-  only:
-    refs:
-      - schedules@netdev/automation
-
-
 schedule:notify-test-success:
   extends:
-#    - .only-nwa-schedules  # TODO UNCOMMENT BEFORE MERGING
     - .notify
   script:
       - ./slack.sh $CI_SLACK_NOTIFICATION_CHANNEL "Successfully built and tested $CI_PROJECT_TITLE $CI_JOB_URL" white_check_mark "Gitlab Pipeline"
   needs: ["unit test"]
   when: on_success
 
-
 schedule:notify-build-failed:
   extends:
-#    - .only-nwa-schedules  # TODO UNCOMMENT BEFORE MERGE
     - .notify
   script:
     - ./slack.sh $CI_SLACK_NOTIFICATION_CHANNEL "Build failed for $CI_PROJECT_TITLE $CI_JOB_URL" zap "Gitlab Pipeline"
@@ -40,7 +34,6 @@ schedule:notify-build-failed:
 
 schedule:notify-test-failed:
   extends:
-#    - .only-nwa-schedules  # TODO UNCOMMENT BEFORE MERGE
     - .notify
   script:
     - ./slack.sh $CI_SLACK_NOTIFICATION_CHANNEL "Successful build but failed test $CI_PROJECT_TITLE $CI_JOB_URL" zap "Gitlab Pipeline"

--- a/ci/scripts/slack.sh
+++ b/ci/scripts/slack.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This is based on https://gitlab.com/gitlab-org/gitlab-qa/-/blob/master/bin/slack
+#
+# Sends Slack notification MSG to CI_SLACK_WEBHOOK_URL (which needs to be set).
+# ICON_EMOJI needs to be set to an icon emoji name (without the `:` around it).
+
+CHANNEL=$1
+MSG=$2
+ICON_EMOJI=$3
+USERNAME=$4
+
+if [ -z "$CHANNEL" ] || [ -z "$CI_SLACK_WEBHOOK_URL" ] || [ -z "$MSG" ] || [ -z "$ICON_EMOJI" ] || [ -z "$USERNAME" ]; then
+    echo "Missing argument(s) - Use: $0 channel message icon_emoji username"
+    echo "and set CI_SLACK_WEBHOOK_URL environment variable."
+else
+    curl -X POST --data-urlencode 'payload={"channel": "#'"$CHANNEL"'", "username": "'"$USERNAME"'", "text": "'"$MSG"'", "icon_emoji": "'":$ICON_EMOJI:"'"}' "$CI_SLACK_WEBHOOK_URL"
+fi


### PR DESCRIPTION
Adds a gitlab CI template for sending slack notifications on scheduled build and/or unittest jobs.

To use it in `.gitlab-ci.yml`:
1. Add the stage `notification` below the `test` stage
2. Include the template
```
include:
  - remote: https://raw.githubusercontent.com/workfloworchestrator/nitpick-style/main/ci/gitlab/notifications.yml
```
(if there is already an `include:` section just append it)
3. Define environment variables in the Gitlab's CI/CD settings
- `CI_SLACK_NOTIFICATION_CHANNEL` name of channel to post to
- `CI_SLACK_WEBHOOK_URL` a valid slack webhook url