### PR TITLE
Make the needs build job optional in notifications.yml

### DIFF
--- a/ci/gitlab/notifications.yml
+++ b/ci/gitlab/notifications.yml
@@ -29,7 +29,9 @@ schedule:notify-build-failed:
     - .notify
   script:
     - ./slack.sh $CI_SLACK_NOTIFICATION_CHANNEL "Build failed for $CI_PROJECT_TITLE $CI_JOB_URL" zap "Gitlab Pipeline"
-  needs: ["build"]
+  needs:
+    - job: "build"
+      optional: true
   when: on_failure
 
 schedule:notify-test-failed:


### PR DESCRIPTION
Make the build job optional in notifications.yml so that we can run it only on master and tags.